### PR TITLE
Bruto/salary for tax

### DIFF
--- a/calc.html
+++ b/calc.html
@@ -1560,11 +1560,11 @@
             : 0;
 
         let taxYear = 0;
-        let remainingSalary =
-          salaryYear +
+        let salaryYearForTax = salaryYear +
           pensionEmployerAboveMonth * 12 +
           pensionCompensationAboveYear +
           gemelEmployerAboveMonth * 12;
+        let remainingSalary = salaryYearForTax;
         let previousLimit = 0;
 
         for (const tier of settings.taxYearTiers) {
@@ -1638,7 +1638,7 @@
 
         let btlMonth = 0;
         let healthMonth = 0;
-        remainingSalary = salaryMonth + gemelEmployerAboveMonth;
+        remainingSalary = salaryYearForTax/12;
         previousLimit = 0;
 
         for (const tier of settings.btlTiers) {
@@ -1661,9 +1661,10 @@
           pensionEmployeeMonth -
           gemelEmployeeMonth +
           havraaMonth;
-
+        const salaryMonthForTax = salaryYearForTax / 12;
         updateSalaryTable({
           salaryMonth,
+          salaryMonthForTax,
           taxMonth,
           btlMonth,
           healthMonth,
@@ -2088,6 +2089,7 @@
 
         [
           { label: "ברוטו", value: data.salaryMonth },
+          { label: "ברוטו שווי למס", value: data.salaryMonthForTax },
           { label: "מס הכנסה", value: -data.taxMonth },
           { label: "ביטוח לאומי", value: -data.btlMonth },
           { label: "מס בריאות", value: -data.healthMonth },


### PR DESCRIPTION
Separating out the number needed to compute tax into `salaryYearForTax` and `salaryMonthForTax`. This makes the calculation clearer and I also added this to be displayed in the grid - for transparency. 
Also changed btl to be computed based on `salaryMonthForTax` instead of `salaryMonth+gemelEmployerAboveMonth`. 

Going forward this change makes it easy to take a parameter of value of extra benefits like car, health insurance, tavim lahag... These will be added to `salaryMonthForTax` and not to `salaryMonth`.